### PR TITLE
Use shared memory Sqlite database

### DIFF
--- a/pages/docs/connecting_to_the_database.md
+++ b/pages/docs/connecting_to_the_database.md
@@ -67,7 +67,7 @@ func main() {
 ### SQLite3
 
 
-**NOTE:** You can also use `:memory:` instead of a path to a file. This will tell SQLite to use a temporary database in system memory. (See [SQLite docs](https://www.sqlite.org/inmemorydb.html) for this.)
+**NOTE:** You can also use `file::memory:?cache=shared` instead of a path to a file. This will tell SQLite to use a temporary database in system memory. (See [SQLite docs](https://www.sqlite.org/inmemorydb.html) for this.)
 
 ```go
 import (


### PR DESCRIPTION
See: https://github.com/go-gorm/gorm/issues/2875

Otherwise you get one Sqlite database per thread, which in go makes things very surprising. Based on your luck you might get routerd to a thread with some data, and sometimes not with data.