### PR TITLE
Fix typo in nested transactions example

### DIFF
--- a/pages/docs/transactions.md
+++ b/pages/docs/transactions.md
@@ -50,12 +50,12 @@ DB.Transaction(func(tx *gorm.DB) error {
   tx.Create(&user1)
 
   tx.Transaction(func(tx2 *gorm.DB) error {
-    tx.Create(&user2)
+    tx2.Create(&user2)
     return errors.New("rollback user2") // Rollback user2
   })
 
   tx.Transaction(func(tx2 *gorm.DB) error {
-    tx.Create(&user3)
+    tx2.Create(&user3)
     return nil
   })
 


### PR DESCRIPTION
- [x] Only changed English documents, translations should change with https://translate.gorm.io/

### What did this pull request do?
Fixed (what I suspect) is a typo in nested transactions example.

I changed tx to tx2 as per the nested function variable.
