### PR TITLE
Add transaction example when handling associations

### DIFF
--- a/pages/docs/transactions.md
+++ b/pages/docs/transactions.md
@@ -25,6 +25,8 @@ tx.Model(&user).Update("Age", 18)
 To perform a set of operations within a transaction, the general flow is as below.
 
 ```go
+lion := Animal{Name: "Lion"}
+
 db.Transaction(func(tx *gorm.DB) error {
   // do some database operations in the transaction (use 'tx' from this point, not 'db')
   if err := tx.Create(&Animal{Name: "Giraffe"}).Error; err != nil {
@@ -32,7 +34,12 @@ db.Transaction(func(tx *gorm.DB) error {
     return err
   }
 
-  if err := tx.Create(&Animal{Name: "Lion"}).Error; err != nil {
+  if err := tx.Create(&lion).Error; err != nil {
+    return err
+  }
+  
+  // Association transaction
+  if err := tx.Model(&lion).Association("Parent").Append(&Parent{Name: "ParentLion"}); err != nil {
     return err
   }
 


### PR DESCRIPTION
Looks like methods like Append( http://v2.gorm.io/docs/associations.html#Append-Associations ) doesn't have the `Error` attribute.

Instead the method it self returns error - https://github.com/go-gorm/gorm/blob/5883490aa773ad8dbc13c901bb4ffec502417477/tests/associations_has_one_test.go#L30-L32