### PR TITLE
Fix typo

### DIFF
--- a/pages/docs/conventions.md
+++ b/pages/docs/conventions.md
@@ -17,7 +17,7 @@ type User struct {
 You can set other fields as primary key with tag `primaryKey`
 
 ```go
-// Set field `AnimalID` as primary field
+// Set field `UUID` as primary field
 type Animal struct {
   ID     int64
   UUID   string `gorm:"primaryKey"`


### PR DESCRIPTION
### What did this pull request do?

Fixed a typo in the documentation. For some reason there was `AnimalID` instead of `UUID`.
