### PR TITLE
Update Sql Builder Documentation

### DIFF
--- a/pages/docs/sql_builder.md
+++ b/pages/docs/sql_builder.md
@@ -8,19 +8,20 @@ layout: page
 Query Raw SQL with `Scan`
 
 ```go
-type Result struct {
+type Users struct {
   ID   int
   Name string
   Age  int
+  Role
 }
 
-var result Result
+var result Users
 db.Raw("SELECT id, name, age FROM users WHERE name = ?", 3).Scan(&result)
 
 db.Raw("SELECT id, name, age FROM users WHERE name = ?", 3).Scan(&result)
 
 var age int
-DB.Raw("select sum(age) from users where role = ?", "admin").Scan(&age)
+db.Raw("select sum(age) from users where role = ?", "admin").Row().Scan(&age)
 ```
 
 `Exec` with Raw SQL

--- a/pages/docs/sql_builder.md
+++ b/pages/docs/sql_builder.md
@@ -8,14 +8,14 @@ layout: page
 Query Raw SQL with `Scan`
 
 ```go
-type Users struct {
+type User struct {
   ID   int
   Name string
   Age  int
   Role
 }
 
-var result Users
+var result User
 db.Raw("SELECT id, name, age FROM users WHERE name = ?", 3).Scan(&result)
 
 db.Raw("SELECT id, name, age FROM users WHERE name = ?", 3).Scan(&result)


### PR DESCRIPTION
# What did this pull request do?

Fix documentation on sql builder on:
1. Struct naming that will produce error `column "age" does not exist ` for result scanning
2. Sql scan for column
```
var age int
db.Raw("select sum(age) from users where role = ?", "admin").Scan(&age)
```
Where will produce error `unsupported destination, should be slice or struct` 

 
