### PR TITLE
Fix association.md

### DIFF
--- a/pages/docs/associations.md
+++ b/pages/docs/associations.md
@@ -101,9 +101,9 @@ Append new associations for `many to many`, `has many`, replace current associat
 ```go
 db.Model(&user).Association("Languages").Append([]Language{languageZH, languageEN})
 
-db.Model(&user).Association("Languages").Append(Language{Name: "DE"})
+db.Model(&user).Association("Languages").Append(&Language{Name: "DE"})
 
-db.Model(&user).Association("CreditCard").Append(CreditCard{Number: "411111111111"})
+db.Model(&user).Association("CreditCard").Append(&CreditCard{Number: "411111111111"})
 ```
 
 ### Replace Associations


### PR DESCRIPTION
## What did this pull request do?

Append associations will break if it does not use pointer, therefore put an `&` before associated model in the document.
