### PR TITLE
Fix typo at method_chaining.md

### DIFF
--- a/pages/docs/method_chaining.md
+++ b/pages/docs/method_chaining.md
@@ -31,7 +31,7 @@ Check out [the full lists](https://github.com/go-gorm/gorm/blob/master/finisher_
 
 After new initialized `*gorm.DB` or a `New Session Method`, following methods call will create a new `Statement` instance instead of using the current one
 
-GROM defined `Session`, `WithContext`, `Debug` methods as `New Session Method`, refer [Session](session.html) for more details
+GORM defined `Session`, `WithContext`, `Debug` methods as `New Session Method`, refer [Session](session.html) for more details
 
 Let explain it with examples:
 


### PR DESCRIPTION

### What did this pull request do?

Fix a typo `GROM` -> `GORM`
