### PR TITLE
Mark the string argument of db.Order() as unsafe

### DIFF
--- a/pages/docs/security.md
+++ b/pages/docs/security.md
@@ -50,6 +50,8 @@ db.Group("name").Having("1 = 1;drop table users;").First(&user)
 db.Raw("select name from users; drop table users;").First(&user)
 
 db.Exec("select name from users; drop table users;")
+
+db.Order("name; drop table users;").First(&user)
 ```
 
 The general rule to avoid SQL injection is don't trust user-submitted data, you can perform whitelist validation to test user input against an existing set of known, approved, and defined input, and when using user's input, only use them as an argument.


### PR DESCRIPTION
### What did this pull request do?

The string version of `db.Order()` is simply casting the given `value` to string without any SQL escape. https://github.com/go-gorm/gorm/blob/v1.20.12/chainable_api.go#L199 (snippets below)

```
	default:
		tx.Statement.AddClause(clause.OrderBy{
			Columns: []clause.OrderByColumn{{
				Column: clause.Column{Name: fmt.Sprint(value), Raw: true},
			}},
		})
	}
```

This patch adds a note about this behaviour.

Sample code to produce the issue:

```
        r := struct{}{}
        db, _ := gorm.Open(sqlite.Open(filepath.Join(os.TempDir(), "gorm.db")), &gorm.Config{})
        dryDB := db.Session(&gorm.Session{DryRun: true})

        result := dryDB.Order("name; drop table users;").Find(&r)
        fmt.Println(result.Statement.SQL.String())
        // Output: SELECT * FROM `` ORDER BY name; drop table users;
```

If the order field is an untrusted user input, it is better to use `clause.OrderByColumn` as the input of `db.Order()` or make use of `db.Clauses()` directly.

```
        r := struct{}{}
        db, _ := gorm.Open(sqlite.Open(filepath.Join(os.TempDir(), "gorm.db")), &gorm.Config{})
        dryDB := db.Session(&gorm.Session{DryRun: true})

        cols := []clause.OrderByColumn{
                        clause.OrderByColumn{Column: clause.Column{Name: "name; drop table users;"}, Desc: true},
        }
        result := dryDB.Clauses(clause.OrderBy{Columns: cols}).Find(&r)

        fmt.Println(result.Statement.SQL.String())
        // Output: SELECT * FROM `` ORDER BY `name; drop table users;` DESC
```