### PR TITLE
fix link to scanner interface

### DIFF
--- a/pages/docs/data_types.md
+++ b/pages/docs/data_types.md
@@ -9,7 +9,7 @@ GORM provides few interfaces that allow users to define well-supported customize
 
 ### Scanner / Valuer
 
-The customized data type has to implement the [Scanner](https://pkg.go.dev/database/sql/sql#Scanner) and [Valuer](https://pkg.go.dev/database/sql/driver#Valuer) interfaces, so GORM knowns to how to receive/save it into the database
+The customized data type has to implement the [Scanner](https://pkg.go.dev/database/sql#Scanner) and [Valuer](https://pkg.go.dev/database/sql/driver#Valuer) interfaces, so GORM knowns to how to receive/save it into the database
 
 For example:
 


### PR DESCRIPTION
### What did this pull request do?
The link to the `Scanner` interface currently results in a 404. This PR sets the proper URL to the interface.