### PR TITLE
[Fix] IN query example

### DIFF
--- a/pages/docs/query.md
+++ b/pages/docs/query.md
@@ -110,7 +110,7 @@ db.Where("name <> ?", "jinzhu").Find(&users)
 // SELECT * FROM users WHERE name <> 'jinzhu';
 
 // IN
-db.Where("name IN ?", []string{"jinzhu", "jinzhu 2"}).Find(&users)
+db.Where("name IN (?)", []string{"jinzhu", "jinzhu 2"}).Find(&users)
 // SELECT * FROM users WHERE name IN ('jinzhu','jinzhu 2');
 
 // LIKE


### PR DESCRIPTION
The IN query example provided will result in the SQL query of form `SELECT * FROM users WHERE name IN ?, ?` which will throw and incorrect query error.

### What did this pull request do?

<!--
provide a general description of the changes in your pull request
-->
Updated the example provided for the IN query. The new example with result in SQL query of form `SELECT * FROM users WHERE name IN (?, ?)`.