### PR TITLE
Fix a syntax error

### DIFF
--- a/pages/docs/constraints.md
+++ b/pages/docs/constraints.md
@@ -31,7 +31,7 @@ db, err := gorm.Open(sqlite.Open("gorm.db"), &gorm.Config{
 })
 ```
 
-GORM allows you setup FOREIGN KEY constraints's `OnDelete`, `OnDelete` option with tag `constraint`, for example:
+GORM allows you setup FOREIGN KEY constraints's `OnDelete`, `OnUpdate` option with tag `constraint`, for example:
 
 ```go
 type User struct {


### PR DESCRIPTION
line 34, you say "`OnDelete`" twice

- [X] **ONLY** change English documents in the Pull Request, translations will be synced and translate them with https://translate.gorm.io/ or it will cause merge conflicts!

### What did this pull request do?

This fix a syntax error on line 34 of pages/docs/constraints.md, you say "`OnDelete`" twice