### PR TITLE
Construction of better connection url to pg

### DIFF
--- a/pages/ar_SA/docs/connecting_to_the_database.md
+++ b/pages/ar_SA/docs/connecting_to_the_database.md
@@ -75,16 +75,29 @@ import (
   "gorm.io/gorm"
 )
 
-dsn := "host=localhost user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
-db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+dsn := url.URL{
+		User:     url.UserPassword("gorm", "gorm"), //username, password
+		Scheme:   "postgres", 
+		Host:     fmt.Sprintf("%s:%s", "localhost", "9920"),//host, port
+		Path:     "gorm", //database name
+		RawQuery: (&url.Values{"sslmode": []string{"disable", "TimeZone": []string{"Asia/Shanghai"}}).Encode(),
+}
+db, err := gorm.Open(postgres.Open(dsn.String()), &gorm.Config{})
 ```
 
 We are using [pgx](https://github.com/jackc/pgx) as postgres's database/sql driver, it enables prepared statement cache by default, to disable it:
 
 ```go
 // https://github.com/go-gorm/postgres
+dsn := url.URL{
+		User:     url.UserPassword("gorm", "gorm"), //username, password
+		Scheme:   "postgres", 
+		Host:     fmt.Sprintf("%s:%s", "localhost", "9920"),//host, port
+		Path:     "gorm", //database name
+		RawQuery: (&url.Values{"sslmode": []string{"disable", "TimeZone": []string{"Asia/Shanghai"}}).Encode(),
+}
 db, err := gorm.Open(postgres.New(postgres.Config{
-  DSN: "user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai",
+  DSN: dsn.String(),
   PreferSimpleProtocol: true, // disables implicit prepared statement usage
 }), &gorm.Config{})
 ```

--- a/pages/de_DE/docs/connecting_to_the_database.md
+++ b/pages/de_DE/docs/connecting_to_the_database.md
@@ -77,16 +77,29 @@ import (
   "gorm.io/gorm"
 )
 
-dsn := "host=localhost user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
-db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+dsn := url.URL{
+		User:     url.UserPassword("gorm", "gorm"), //username, password
+		Scheme:   "postgres", 
+		Host:     fmt.Sprintf("%s:%s", "localhost", "9920"),//host, port
+		Path:     "gorm", //database name
+		RawQuery: (&url.Values{"sslmode": []string{"disable", "TimeZone": []string{"Asia/Shanghai"}}).Encode(),
+}
+db, err := gorm.Open(postgres.Open(dsn.String()), &gorm.Config{})
 ```
 
 We are using [pgx](https://github.com/jackc/pgx) as postgres's database/sql driver, it enables prepared statement cache by default, to disable it:
 
 ```go
 // https://github.com/go-gorm/postgres
+dsn := url.URL{
+		User:     url.UserPassword("gorm", "gorm"), //username, password
+		Scheme:   "postgres", 
+		Host:     fmt.Sprintf("%s:%s", "localhost", "9920"),//host, port
+		Path:     "gorm", //database name
+		RawQuery: (&url.Values{"sslmode": []string{"disable", "TimeZone": []string{"Asia/Shanghai"}}).Encode(),
+}
 db, err := gorm.Open(postgres.New(postgres.Config{
-  DSN: "user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai",
+  DSN: dsn.String(),
   PreferSimpleProtocol: true, // disables implicit prepared statement usage
 }), &gorm.Config{})
 ```

--- a/pages/docs/connecting_to_the_database.md
+++ b/pages/docs/connecting_to_the_database.md
@@ -77,18 +77,33 @@ gormDB, err := gorm.Open(mysql.New(mysql.Config{
 import (
   "gorm.io/driver/postgres"
   "gorm.io/gorm"
+  "net/url"
 )
 
-dsn := "host=localhost user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
-db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+dsn := url.URL{
+		User:     url.UserPassword("gorm", "gorm"), //username, password
+		Scheme:   "postgres", 
+		Host:     fmt.Sprintf("%s:%s", "localhost", "9920"),//host, port
+		Path:     "gorm", //database name
+		RawQuery: (&url.Values{"sslmode": []string{"disable", "TimeZone": []string{"Asia/Shanghai"}}).Encode(),
+}
+
+db, err := gorm.Open(postgres.Open(dsn.String()), &gorm.Config{})
 ```
 
 We are using [pgx](https://github.com/jackc/pgx) as postgres's database/sql driver, it enables prepared statement cache by default, to disable it:
 
 ```go
 // https://github.com/go-gorm/postgres
+dsn := url.URL{
+		User:     url.UserPassword("gorm", "gorm"), //username, password
+		Scheme:   "postgres", 
+		Host:     fmt.Sprintf("%s:%s", "localhost", "9920"),//host, port
+		Path:     "gorm", //database name
+		RawQuery: (&url.Values{"sslmode": []string{"disable", "TimeZone": []string{"Asia/Shanghai"}}).Encode(),
+}
 db, err := gorm.Open(postgres.New(postgres.Config{
-  DSN: "user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai",
+  DSN: dsn.String(),
   PreferSimpleProtocol: true, // disables implicit prepared statement usage
 }), &gorm.Config{})
 ```

--- a/pages/es_ES/docs/connecting_to_the_database.md
+++ b/pages/es_ES/docs/connecting_to_the_database.md
@@ -77,16 +77,29 @@ import (
   "gorm.io/gorm"
 )
 
-dsn := "host=localhost user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
-db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+dsn := url.URL{
+		User:     url.UserPassword("gorm", "gorm"), //username, password
+		Scheme:   "postgres", 
+		Host:     fmt.Sprintf("%s:%s", "localhost", "9920"),//host, port
+		Path:     "gorm", //database name
+		RawQuery: (&url.Values{"sslmode": []string{"disable", "TimeZone": []string{"Asia/Shanghai"}}).Encode(),
+}
+db, err := gorm.Open(postgres.Open(dsn.String()), &gorm.Config{})
 ```
 
 We are using [pgx](https://github.com/jackc/pgx) as postgres's database/sql driver, it enables prepared statement cache by default, to disable it:
 
 ```go
 // https://github.com/go-gorm/postgres
+dsn := url.URL{
+		User:     url.UserPassword("gorm", "gorm"), //username, password
+		Scheme:   "postgres", 
+		Host:     fmt.Sprintf("%s:%s", "localhost", "9920"),//host, port
+		Path:     "gorm", //database name
+		RawQuery: (&url.Values{"sslmode": []string{"disable", "TimeZone": []string{"Asia/Shanghai"}}).Encode(),
+}
 db, err := gorm.Open(postgres.New(postgres.Config{
-  DSN: "user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai",
+  DSN: dsn.String(),
   PreferSimpleProtocol: true, // disables implicit prepared statement usage
 }), &gorm.Config{})
 ```

--- a/pages/fr_FR/docs/connecting_to_the_database.md
+++ b/pages/fr_FR/docs/connecting_to_the_database.md
@@ -77,16 +77,29 @@ import (
   "gorm.io/gorm"
 )
 
-dsn := "host=localhost user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
-db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+dsn := url.URL{
+		User:     url.UserPassword("gorm", "gorm"), //username, password
+		Scheme:   "postgres", 
+		Host:     fmt.Sprintf("%s:%s", "localhost", "9920"),//host, port
+		Path:     "gorm", //database name
+		RawQuery: (&url.Values{"sslmode": []string{"disable", "TimeZone": []string{"Asia/Shanghai"}}).Encode(),
+}
+db, err := gorm.Open(postgres.Open(dsn.String()), &gorm.Config{})
 ```
 
 We are using [pgx](https://github.com/jackc/pgx) as postgres's database/sql driver, it enables prepared statement cache by default, to disable it:
 
 ```go
 // https://github.com/go-gorm/postgres
+dsn := url.URL{
+		User:     url.UserPassword("gorm", "gorm"), //username, password
+		Scheme:   "postgres", 
+		Host:     fmt.Sprintf("%s:%s", "localhost", "9920"),//host, port
+		Path:     "gorm", //database name
+		RawQuery: (&url.Values{"sslmode": []string{"disable", "TimeZone": []string{"Asia/Shanghai"}}).Encode(),
+}
 db, err := gorm.Open(postgres.New(postgres.Config{
-  DSN: "user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai",
+  DSN: dsn.String(),
   PreferSimpleProtocol: true, // disables implicit prepared statement usage
 }), &gorm.Config{})
 ```

--- a/pages/id_ID/docs/connecting_to_the_database.md
+++ b/pages/id_ID/docs/connecting_to_the_database.md
@@ -77,16 +77,29 @@ import (
   "gorm.io/gorm"
 )
 
-dsn := "host=localhost user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
-db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+dsn := url.URL{
+		User:     url.UserPassword("gorm", "gorm"), //username, password
+		Scheme:   "postgres", 
+		Host:     fmt.Sprintf("%s:%s", "localhost", "9920"),//host, port
+		Path:     "gorm", //database name
+		RawQuery: (&url.Values{"sslmode": []string{"disable", "TimeZone": []string{"Asia/Shanghai"}}).Encode(),
+}
+db, err := gorm.Open(postgres.Open(dsn.String()), &gorm.Config{})
 ```
 
 kita menggunakan [pgx](https://github.com/jackc/pgx)  sebagai database Postgres's/sql driver , memungkinkan menyiapkan cache secara default,  unutk menonaktikannya :
 
 ```go
 // https://github.com/go-gorm/postgres
+dsn := url.URL{
+		User:     url.UserPassword("gorm", "gorm"), //username, password
+		Scheme:   "postgres", 
+		Host:     fmt.Sprintf("%s:%s", "localhost", "9920"),//host, port
+		Path:     "gorm", //database name
+		RawQuery: (&url.Values{"sslmode": []string{"disable", "TimeZone": []string{"Asia/Shanghai"}}).Encode(),
+}
 db, err := gorm.Open(postgres.New(postgres.Config{
-  DSN: "user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai",
+  DSN: dsn.String(),
   PreferSimpleProtocol: true, // disables implicit prepared statement usage
 }), &gorm.Config{})
 ```

--- a/pages/it_IT/docs/connecting_to_the_database.md
+++ b/pages/it_IT/docs/connecting_to_the_database.md
@@ -77,16 +77,29 @@ import (
   "gorm.io/gorm"
 )
 
-dsn := "host=localhost user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
-db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+dsn := url.URL{
+		User:     url.UserPassword("gorm", "gorm"), //username, password
+		Scheme:   "postgres", 
+		Host:     fmt.Sprintf("%s:%s", "localhost", "9920"),//host, port
+		Path:     "gorm", //database name
+		RawQuery: (&url.Values{"sslmode": []string{"disable", "TimeZone": []string{"Asia/Shanghai"}}).Encode(),
+}
+db, err := gorm.Open(postgres.Open(dsn.String()), &gorm.Config{})
 ```
 
 We are using [pgx](https://github.com/jackc/pgx) as postgres's database/sql driver, it enables prepared statement cache by default, to disable it:
 
 ```go
 // https://github.com/go-gorm/postgres
+dsn := url.URL{
+		User:     url.UserPassword("gorm", "gorm"), //username, password
+		Scheme:   "postgres", 
+		Host:     fmt.Sprintf("%s:%s", "localhost", "9920"),//host, port
+		Path:     "gorm", //database name
+		RawQuery: (&url.Values{"sslmode": []string{"disable", "TimeZone": []string{"Asia/Shanghai"}}).Encode(),
+}
 db, err := gorm.Open(postgres.New(postgres.Config{
-  DSN: "user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai",
+  DSN: dsn.String(),
   PreferSimpleProtocol: true, // disables implicit prepared statement usage
 }), &gorm.Config{})
 ```

--- a/pages/ja_JP/docs/connecting_to_the_database.md
+++ b/pages/ja_JP/docs/connecting_to_the_database.md
@@ -77,16 +77,29 @@ import (
   "gorm.io/gorm"
 )
 
-dsn := "host=localhost user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
-db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+dsn := url.URL{
+		User:     url.UserPassword("gorm", "gorm"), //username, password
+		Scheme:   "postgres", 
+		Host:     fmt.Sprintf("%s:%s", "localhost", "9920"),//host, port
+		Path:     "gorm", //database name
+		RawQuery: (&url.Values{"sslmode": []string{"disable", "TimeZone": []string{"Asia/Shanghai"}}).Encode(),
+}
+db, err := gorm.Open(postgres.Open(dsn.String()), &gorm.Config{})
 ```
 
 Postgresのdatabase/sqlドライバとして [pgx](https://github.com/jackc/pgx) を使用しています。これはデフォルトでprepared statement cacheを有効にしています。無効にするには:
 
 ```go
 // https://github.com/go-gorm/postgres
+dsn := url.URL{
+		User:     url.UserPassword("gorm", "gorm"), //username, password
+		Scheme:   "postgres", 
+		Host:     fmt.Sprintf("%s:%s", "localhost", "9920"),//host, port
+		Path:     "gorm", //database name
+		RawQuery: (&url.Values{"sslmode": []string{"disable", "TimeZone": []string{"Asia/Shanghai"}}).Encode(),
+}
 db, err := gorm.Open(postgres.New(postgres.Config{
-  DSN: "user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai",
+  DSN: dsn.String(),
   PreferSimpleProtocol: true, // disables implicit prepared statement usage
 }), &gorm.Config{})
 ```

--- a/pages/ko_KR/docs/connecting_to_the_database.md
+++ b/pages/ko_KR/docs/connecting_to_the_database.md
@@ -77,16 +77,29 @@ import (
   "gorm.io/gorm"
 )
 
-dsn := "host=localhost user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
-db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+dsn := url.URL{
+		User:     url.UserPassword("gorm", "gorm"), //username, password
+		Scheme:   "postgres", 
+		Host:     fmt.Sprintf("%s:%s", "localhost", "9920"),//host, port
+		Path:     "gorm", //database name
+		RawQuery: (&url.Values{"sslmode": []string{"disable", "TimeZone": []string{"Asia/Shanghai"}}).Encode(),
+}
+db, err := gorm.Open(postgres.Open(dsn.String()), &gorm.Config{})
 ```
 
 We are using [pgx](https://github.com/jackc/pgx) as postgres's database/sql driver, it enables prepared statement cache by default, to disable it:
 
 ```go
 // https://github.com/go-gorm/postgres
+dsn := url.URL{
+		User:     url.UserPassword("gorm", "gorm"), //username, password
+		Scheme:   "postgres", 
+		Host:     fmt.Sprintf("%s:%s", "localhost", "9920"),//host, port
+		Path:     "gorm", //database name
+		RawQuery: (&url.Values{"sslmode": []string{"disable", "TimeZone": []string{"Asia/Shanghai"}}).Encode(),
+}
 db, err := gorm.Open(postgres.New(postgres.Config{
-  DSN: "user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai",
+  DSN: dsn.String(),
   PreferSimpleProtocol: true, // disables implicit prepared statement usage
 }), &gorm.Config{})
 ```

--- a/pages/pl_PL/docs/connecting_to_the_database.md
+++ b/pages/pl_PL/docs/connecting_to_the_database.md
@@ -77,16 +77,29 @@ import (
   "gorm.io/gorm"
 )
 
-dsn := "host=localhost user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
-db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+dsn := url.URL{
+		User:     url.UserPassword("gorm", "gorm"), //username, password
+		Scheme:   "postgres", 
+		Host:     fmt.Sprintf("%s:%s", "localhost", "9920"),//host, port
+		Path:     "gorm", //database name
+		RawQuery: (&url.Values{"sslmode": []string{"disable", "TimeZone": []string{"Asia/Shanghai"}}).Encode(),
+}
+db, err := gorm.Open(postgres.Open(dsn.String()), &gorm.Config{})
 ```
 
 We are using [pgx](https://github.com/jackc/pgx) as postgres's database/sql driver, it enables prepared statement cache by default, to disable it:
 
 ```go
 // https://github.com/go-gorm/postgres
+dsn := url.URL{
+		User:     url.UserPassword("gorm", "gorm"), //username, password
+		Scheme:   "postgres", 
+		Host:     fmt.Sprintf("%s:%s", "localhost", "9920"),//host, port
+		Path:     "gorm", //database name
+		RawQuery: (&url.Values{"sslmode": []string{"disable", "TimeZone": []string{"Asia/Shanghai"}}).Encode(),
+}
 db, err := gorm.Open(postgres.New(postgres.Config{
-  DSN: "user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai",
+  DSN: dsn.String(),
   PreferSimpleProtocol: true, // disables implicit prepared statement usage
 }), &gorm.Config{})
 ```

--- a/pages/ru_RU/docs/connecting_to_the_database.md
+++ b/pages/ru_RU/docs/connecting_to_the_database.md
@@ -77,16 +77,29 @@ import (
   "gorm.io/gorm"
 )
 
-dsn := "host=localhost user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
-db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+dsn := url.URL{
+		User:     url.UserPassword("gorm", "gorm"), //username, password
+		Scheme:   "postgres", 
+		Host:     fmt.Sprintf("%s:%s", "localhost", "9920"),//host, port
+		Path:     "gorm", //database name
+		RawQuery: (&url.Values{"sslmode": []string{"disable", "TimeZone": []string{"Asia/Shanghai"}}).Encode(),
+}
+db, err := gorm.Open(postgres.Open(dsn.String()), &gorm.Config{})
 ```
 
 Мы используем [pgx](https://github.com/jackc/pgx) в качестве драйвера sql базы данных postgres, он включает кэш подготовленных выражений по умолчанию, чтобы отключить его:
 
 ```go
 // https://github.com/go-gorm/postgres
+dsn := url.URL{
+		User:     url.UserPassword("gorm", "gorm"), //username, password
+		Scheme:   "postgres", 
+		Host:     fmt.Sprintf("%s:%s", "localhost", "9920"),//host, port
+		Path:     "gorm", //database name
+		RawQuery: (&url.Values{"sslmode": []string{"disable", "TimeZone": []string{"Asia/Shanghai"}}).Encode(),
+}
 db, err := gorm.Open(postgres.New(postgres.Config{
-  DSN: "user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai",
+  DSN: dsn.String(),
   PreferSimpleProtocol: true, // disables implicit prepared statement usage
 }), &gorm.Config{})
 ```

--- a/pages/tr_TR/docs/connecting_to_the_database.md
+++ b/pages/tr_TR/docs/connecting_to_the_database.md
@@ -77,16 +77,29 @@ import (
   "gorm.io/gorm"
 )
 
-dsn := "host=localhost user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
-db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+dsn := url.URL{
+		User:     url.UserPassword("gorm", "gorm"), //username, password
+		Scheme:   "postgres", 
+		Host:     fmt.Sprintf("%s:%s", "localhost", "9920"),//host, port
+		Path:     "gorm", //database name
+		RawQuery: (&url.Values{"sslmode": []string{"disable", "TimeZone": []string{"Asia/Shanghai"}}).Encode(),
+}
+db, err := gorm.Open(postgres.Open(dsn.String()), &gorm.Config{})
 ```
 
 We are using [pgx](https://github.com/jackc/pgx) as postgres's database/sql driver, it enables prepared statement cache by default, to disable it:
 
 ```go
 // https://github.com/go-gorm/postgres
+dsn := url.URL{
+		User:     url.UserPassword("gorm", "gorm"), //username, password
+		Scheme:   "postgres", 
+		Host:     fmt.Sprintf("%s:%s", "localhost", "9920"),//host, port
+		Path:     "gorm", //database name
+		RawQuery: (&url.Values{"sslmode": []string{"disable", "TimeZone": []string{"Asia/Shanghai"}}).Encode(),
+}
 db, err := gorm.Open(postgres.New(postgres.Config{
-  DSN: "user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai",
+  DSN: dsn.String(),
   PreferSimpleProtocol: true, // disables implicit prepared statement usage
 }), &gorm.Config{})
 ```

--- a/pages/zh_CN/docs/connecting_to_the_database.md
+++ b/pages/zh_CN/docs/connecting_to_the_database.md
@@ -77,16 +77,29 @@ import (
   "gorm.io/gorm"
 )
 
-dsn := "host=localhost user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
-db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+dsn := url.URL{
+		User:     url.UserPassword("gorm", "gorm"), //username, password
+		Scheme:   "postgres", 
+		Host:     fmt.Sprintf("%s:%s", "localhost", "9920"),//host, port
+		Path:     "gorm", //database name
+		RawQuery: (&url.Values{"sslmode": []string{"disable", "TimeZone": []string{"Asia/Shanghai"}}).Encode(),
+}
+db, err := gorm.Open(postgres.Open(dsn.String()), &gorm.Config{})
 ```
 
 我们使用 [pgx](https://github.com/jackc/pgx) 作为 postgres 的 database/sql 驱动，默认情况下，它会启用 prepared statement 缓存，你可以这样禁用它：
 
 ```go
 // https://github.com/go-gorm/postgres
+dsn := url.URL{
+		User:     url.UserPassword("gorm", "gorm"), //username, password
+		Scheme:   "postgres", 
+		Host:     fmt.Sprintf("%s:%s", "localhost", "9920"),//host, port
+		Path:     "gorm", //database name
+		RawQuery: (&url.Values{"sslmode": []string{"disable", "TimeZone": []string{"Asia/Shanghai"}}).Encode(),
+}
 db, err := gorm.Open(postgres.New(postgres.Config{
-  DSN: "user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai",
+  DSN: dsn.String(),
   PreferSimpleProtocol: true, // disables implicit prepared statement usage
 }), &gorm.Config{})
 ```


### PR DESCRIPTION
- [] **ONLY** change English documents in the Pull Request, translations will be synced and translate them with https://translate.gorm.io/ or it will cause merge conflicts!

### What did this pull request do?

Added a better way to construct connection url for pg.
The earlier string provided would autoMigrate into database name "postgres" instead of specified database name.
