### PR TITLE
Incorrect slow SQL time for logger in release notes

### DIFF
--- a/pages/docs/v2_release_note.md
+++ b/pages/docs/v2_release_note.md
@@ -388,7 +388,7 @@ db, err := gorm.Open(sqlite.Open("gorm.db"), &gorm.Config{
 
 * Context support
 * Customize/turn off the colors in the log
-* Slow SQL log, default slow SQL time is 100ms
+* Slow SQL log, default slow SQL time is 200ms
 * Optimized the SQL log format so that it can be copied and executed in a database console
 
 #### Transaction Mode


### PR DESCRIPTION
Slow SQL threshold value is incorrect (outdated) in the doc - the threshold is now 200ms.

https://github.com/go-gorm/gorm/blob/master/logger/logger.go#L63