### PR TITLE
Fix spelling of "primary" for `gorm.DB#Delete()` batch delete

### DIFF
--- a/pages/docs/delete.md
+++ b/pages/docs/delete.md
@@ -47,7 +47,7 @@ func (u *User) BeforeDelete(tx *gorm.DB) (err error) {
 
 ## <span id="batch_delete">Batch Delete</span>
 
-The specified value has no priamry value, GORM will perform a batch delete, it will delete all matched records
+The specified value has no primary value, GORM will perform a batch delete, it will delete all matched records
 
 ```go
 db.Where("email LIKE ?", "%jinzhu%").Delete(Email{})


### PR DESCRIPTION
- [x] **ONLY** change English documents in the Pull Request, translations will be synced and translate them with https://translate.gorm.io/ or it will cause merge conflicts!

### What did this pull request do?

Fixed a typo [here](https://gorm.io/docs/delete.html#Batch-Delete) (primary was misspelled).