### PR TITLE
Added return names to logger.Interface.Trace

### DIFF
--- a/pages/docs/logger.md
+++ b/pages/docs/logger.md
@@ -61,6 +61,6 @@ type Interface interface {
 	Info(context.Context, string, ...interface{})
 	Warn(context.Context, string, ...interface{})
 	Error(context.Context, string, ...interface{})
-	Trace(ctx context.Context, begin time.Time, fc func() (string, int64), err error)
+	Trace(ctx context.Context, begin time.Time, fc func() (sql string, rowsAffected int64), err error)
 }
 ```


### PR DESCRIPTION
- [x] **ONLY** change English documents in the Pull Request, translations will be synced and translate them with https://translate.gorm.io/ or it will cause merge conflicts!

### What did this pull request do?

Mirror the changes from go-gorm/gorm#4450

I found it hard to understand what the `fc` argument was for in the `logger.Interface` type, so I added return value names.
