### PR TITLE
Fix incorrect example in overriding many_to_many foreign keys

### DIFF
--- a/pages/docs/many_to_many.md
+++ b/pages/docs/many_to_many.md
@@ -65,7 +65,7 @@ To override them, you can use tag `foreignKey`, `references`, `joinForeignKey`, 
 ```go
 type User struct {
 	gorm.Model
-	Profiles []Profile `gorm:"many2many:user_profiles;foreignKey:Refer;joinForeignKey:UserReferID;References:UserRefer;JoinReferences:UserRefer"`
+	Profiles []Profile `gorm:"many2many:user_profiles;foreignKey:Refer;joinForeignKey:UserReferID;References:UserRefer;JoinReferences:ProfileRefer"`
 	Refer    uint      `gorm:"index:,unique"`
 }
 


### PR DESCRIPTION
- [x] **ONLY** change English documents in the Pull Request, translations will be synced and translate them with https://translate.gorm.io/ or it will cause merge conflicts!

### What did this pull request do?

Fix incorrect example in overriding many_to_many foreign keys. The JoinReferences tag's value is incorrect.

<!--
provide a general description of the changes in your pull request
-->
