### PR TITLE
Update many_to_many.md

### DIFF
--- a/pages/docs/many_to_many.md
+++ b/pages/docs/many_to_many.md
@@ -65,7 +65,7 @@ To override them, you can use tag `foreignKey`, `references`, `joinForeignKey`, 
 ```go
 type User struct {
 	gorm.Model
-	Profiles []Profile `gorm:"many2many:user_profiles;foreignKey:Refer;joinForeignKey:UserReferID;References:UserRefer;JoinReferences:ProfileRefer"`
+	Profiles []Profile `gorm:"many2many:user_profiles;foreignKey:Refer;joinForeignKey:UserReferID;References:UserRefer;joinReferences:ProfileRefer"`
 	Refer    uint      `gorm:"index:,unique"`
 }
 


### PR DESCRIPTION
Minor capitalization error

- [x] **ONLY** change English documents in the Pull Request, translations will be synced and translate them with https://translate.gorm.io/ or it will cause merge conflicts!

### What did this pull request do?

`joinReferences` is referenced in Pascal case in the documentation, and then capitalized camel case in the example.