### PR TITLE
Connecting to PostgreSQL database with pgx driver

### DIFF
--- a/pages/docs/connecting_to_the_database.md
+++ b/pages/docs/connecting_to_the_database.md
@@ -121,7 +121,7 @@ import (
   "gorm.io/gorm"
 )
 
-sqlDB, err := sql.Open("postgres", "mydb_dsn")
+sqlDB, err := sql.Open("pgx", "mydb_dsn")
 gormDB, err := gorm.Open(postgres.New(postgres.Config{
   Conn: sqlDB,
 }), &gorm.Config{})


### PR DESCRIPTION
- [] **ONLY** change English documents in the Pull Request, translations will be synced and translate them with https://translate.gorm.io/ or it will cause merge conflicts!

### What did this pull request do?

In connecting to the database with existing database connection example `postgres` driver name is used along with `gorm.io/driver/postgres` driver.
`gorm/driver/postgres` is using `pgx` driver underneath. Pgx registers itself with `pgx` as driver name.
Refer to https://github.com/jackc/pgx/blob/2799739ef37f11909f6c1663cf7e77faf80fb592/stdlib/sql.go#L104

Using current example causes error
> sql: unknown driver "postgres" (forgotten import?)

This PR changes driver name used in example to `pgx`