### PR TITLE
refactor: remove misunderstood use cases

### DIFF
--- a/pages/docs/query.md
+++ b/pages/docs/query.md
@@ -72,9 +72,6 @@ Objects can be retrieved using primary key by using [Inline Conditions](#inline_
 db.First(&user, 10)
 // SELECT * FROM users WHERE id = 10;
 
-db.First(&user, "10")
-// SELECT * FROM users WHERE id = 10;
-
 db.Find(&users, []int{1,2,3})
 // SELECT * FROM users WHERE id IN (1,2,3);
 ```
@@ -420,7 +417,6 @@ query := db.Table("order").Select("MAX(order.finished_at) as latest").Joins("lef
 db.Model(&Order{}).Joins("join (?) q on order.finished_at = q.latest", query).Scan(&results)
 // SELECT `order`.`user_id`,`order`.`finished_at` FROM `order` join (SELECT MAX(order.finished_at) as latest FROM `order` left join user user on order.user_id = user.id WHERE user.age > 18 GROUP BY `order`.`user_id`) q on order.finished_at = q.latest
 ```
-
 
 ## <span id="scan">Scan</span>
 


### PR DESCRIPTION
- [x] **ONLY** change English documents in the Pull Request, translations will be synced and translate them with https://translate.gorm.io/ or it will cause merge conflicts!

### What did this pull request do?

<!--
provide a general description of the changes in your pull request
-->

```go
db.First(&user, "10")
// SELECT * FROM users WHERE id = 10;
```
I think this is a misleading use case.
1. Makes people think that id type string can also be used.
2. The actual sql is `SELECT * FROM users WHERE id = "10";` even though the primary key is number. [statement.go#L445](https://github.com/go-gorm/gorm/blob/master/statement.go#L445)
3. We also don't have to convert to number, I think that's what the user should do.

close https://github.com/go-gorm/gorm/issues/5312