### PR TITLE
Fixed typo in Migrator.CreateConstraint()

### DIFF
--- a/pages/docs/v2_release_note.md
+++ b/pages/docs/v2_release_note.md
@@ -549,8 +549,8 @@ db.Model(&MyTable{}).AddForeignKey("profile_id", "profiles(id)", "NO ACTION", "N
 Now you add constraints as follows:
 
 ```go
-db.Migrator().CreateConstraint(&Users{}), "Profiles")
-db.Migrator().CreateConstraint(&Users{}), "fk_users_profiles")
+db.Migrator().CreateConstraint(&Users{}, "Profiles")
+db.Migrator().CreateConstraint(&Users{}, "fk_users_profiles")
 ```
 
 which translates to the following sql code for postgres:


### PR DESCRIPTION
## Fixed a typo

Remove the parenthesis at the end of the `&Users{}`

Incorrect
```go
db.Migrator().CreateConstraint(&Users{}), "Profiles")
db.Migrator().CreateConstraint(&Users{}), "fk_users_profiles")
```

Correct
```go
db.Migrator().CreateConstraint(&Users{}, "Profiles")
db.Migrator().CreateConstraint(&Users{}, "fk_users_profiles")
```