### PR TITLE
Change DB.Where to db.Where

### DIFF
--- a/pages/docs/query.md
+++ b/pages/docs/query.md
@@ -395,7 +395,7 @@ db.Joins("Company").Find(&users)
 Join with conditions
 
 ```go
-db.Joins("Company", DB.Where(&Company{Alive: true})).Find(&users)
+db.Joins("Company", db.Where(&Company{Alive: true})).Find(&users)
 // SELECT `users`.`id`,`users`.`name`,`users`.`age`,`Company`.`id` AS `Company__id`,`Company`.`name` AS `Company__name` FROM `users` LEFT JOIN `companies` AS `Company` ON `users`.`company_id` = `Company`.`id` AND `Company`.`alive` = true;
 ```
 


### PR DESCRIPTION
I believe this example "Join with conditions" query is meant to use the regular gormDB db.Where, but the docs currently have it using DB.Where

On the other hand, maybe you intended to guide users to use the regular sql db accessible at db.DB(). In that case, it should be made clear in the text preceding this example.

### What did this pull request do?

Use the lowercase db to indicate you're using the gormDB `.Where`
