### PR TITLE
Add import for MySQL example

### DIFF
--- a/pages/docs/connecting_to_the_database.md
+++ b/pages/docs/connecting_to_the_database.md
@@ -46,6 +46,7 @@ GORM allows customize the MySQL driver with the `DriverName` option, for example
 ```go
 import (
   _ "example.com/my_mysql_driver"
+  "gorm.io/driver/mysql"
   "gorm.io/gorm"
 )
 


### PR DESCRIPTION
The example uses the package, `gorm.io/driver/mysql`, for `mysql.New(...)` and `mysql.Config{}`. I added the import to the docs so that it is clearer that this import is required for the example to work.

- [] **ONLY** change English documents in the Pull Request, translations will be synced and translate them with https://translate.gorm.io/ or it will cause merge conflicts!

### What did this pull request do?

<!--
provide a general description of the changes in your pull request
-->
