### PR TITLE
Update dbresolver.md

### DIFF
--- a/pages/es_ES/docs/dbresolver.md
+++ b/pages/es_ES/docs/dbresolver.md
@@ -90,7 +90,7 @@ db.Clauses(dbresolver.Use("secondary"), dbresolver.Write).First(&user)
 
 When using transaction, DBResolver will keep using the transaction and won't switch to sources/replicas based on configuration
 
-But you can specifies which DB to use before starting a transaction, for example:
+But you can specify which DB to use before starting a transaction, for example:
 
 ```go
 // Start transaction based on default replicas db


### PR DESCRIPTION
### What did this pull request do?
- Fixed a typo in **Transaction** part:
**But you can ~specifies~ (specify) which DB to use before starting a transaction**

```diff
- But you can specifies which DB to use before starting a transaction
+ But you can specify which DB to use before starting a transaction
