### PR TITLE
Add link to article on strongly typed JSON fields

### DIFF
--- a/pages/community.md
+++ b/pages/community.md
@@ -22,6 +22,8 @@ layout: page
 
 * Article that validate GORM as ORM to Golang with CRUD implementation with SQLite database on tests - [looking-for-an-orm-to-database-layer-with-golang](https://medium.com/@rafaelholanda90/continuing-looking-for-an-orm-to-database-layer-with-golang-7fee0316a989)
 
+* [Strongly typed JSON/JSONB fields in GORM](https://www.terminateandstayresident.com/2022-07-13/orm-json)
+
 ## Videos
 
 * Gorm quick start tutorial by [piexlmax](https://github.com/piexlmax) - [GORM V2 quick start](https://www.bilibili.com/video/BV1E64y1472a#reply5032293079)


### PR DESCRIPTION
Add an article link to the `GORM Community` page describing how to use strongly typed JSON fields with GORM