### PR TITLE
add missing keys to yaml

### DIFF
--- a/pages/de_DE/404.swig
+++ b/pages/de_DE/404.swig
@@ -1,7 +1,7 @@
 ---
 layout: raw
 description: Die fantastische ORM Bibliothek für Golang, stets auf Entwickler-Freundlichkeit aus.
-Die fantastische ORM Bibliothek für Golang
+subtitle: Die fantastische ORM Bibliothek für Golang
 comments: false
 ---
 

--- a/pages/pt_BR/404.swig
+++ b/pages/pt_BR/404.swig
@@ -1,8 +1,8 @@
 ---
 layout: raw
-A fantástica biblioteca ORM para Golang, projetada para ser amigável para desenvolvedores.
-A fantástica biblioteca ORM para Golang
-comentários: falso
+description: A fantástica biblioteca ORM para Golang, projetada para ser amigável para desenvolvedores.
+subtitle: A fantástica biblioteca ORM para Golang
+comments: false
 ---
 
 <div class="container page-not-found">


### PR DESCRIPTION
### What did this pull request do?

Running `hexo serve` on the current `master` branch results in two errors, the first of which is:

```
    reason: 'can not read a block mapping entry; a multiline key may not be an implicit key',
    mark: {
      name: null,
      buffer: 'layout: raw\n' +
        'A fantástica biblioteca ORM para Golang, projetada para ser amigável para desenvolvedores.\n' +
        'A fantástica biblioteca ORM para Golang\n' +
        'comentários: falso\n',
      position: 154,
      line: 3,
      column: 11,
      snippet: ' 1 | layout: raw\n' +
        ' 2 | A fantástica biblioteca ORM para Golang, pr ...\n' +
        ' 3 | A fantástica biblioteca ORM para Golang\n' +
        ' 4 | comentários: falso\n' +
        '----------------^'
    }
  }
} Process failed: %s pt_BR/404.swig
```

This is because the yaml for two of the 404 pages was broken. In one case, the keys had been also translated into Portuguese, and in another case, the key was missing completely.

This PR adds in the missing keys.
