### PR TITLE
use https instead of http where supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Gorm Offical Site
 
-This website is for [GORM](https://github.com/go-gorm/gorm), you can access its content at [http://gorm.io](http://gorm.io)
+This website is for [GORM](https://github.com/go-gorm/gorm), you can access its content at [https://gorm.io](https://gorm.io)
 
 ![build](https://github.com/go-gorm/gorm.io/workflows/build/badge.svg)
 
@@ -20,7 +20,7 @@ To translate GORM in your language, you will need to post a request in the [Gith
 
 ## Developing this Site
 
-This site is built with [hexo](http://hexo.io)
+This site is built with [hexo](https://hexo.io)
 
 ```
 $ npm install

--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ source_dir: pages
 skip_render: [driver/**, plugin/**, datatypes.html, gorm.html, hints.html, gen.html, sharding.html]
 
 # URL
-url: http://gorm.io
+url: https://gorm.io
 root: /
 permalink: :year/:month/:day/:title/
 permalink_defaults:

--- a/pages/docs/v2_release_note.md
+++ b/pages/docs/v2_release_note.md
@@ -24,7 +24,7 @@ GORM 2.0 is a rewrite from scratch, it introduces some incompatible-API change a
 
 ## How To Upgrade
 
-* GORM's developments moved to [github.com/go-gorm](https://github.com/go-gorm), and its import path changed to `gorm.io/gorm`, for previous projects, you can keep using `github.com/jinzhu/gorm` [GORM V1 Document](http://v1.gorm.io/)
+* GORM's developments moved to [github.com/go-gorm](https://github.com/go-gorm), and its import path changed to `gorm.io/gorm`, for previous projects, you can keep using `github.com/jinzhu/gorm` [GORM V1 Document](https://v1.gorm.io/)
 * Database drivers have been split into separate projects, e.g: [github.com/go-gorm/sqlite](https://github.com/go-gorm/sqlite), and its import path also changed to `gorm.io/driver/sqlite`
 
 ### Install


### PR DESCRIPTION
### What did this pull request do?

A number of links in the documentation and config were using `http://` where `https://` is supported. All of these will redirect from http to https, but there's no reason not to just use https directly.
