### PR TITLE
fix foreign key name in has_one.md

### DIFF
--- a/pages/docs/has_one.md
+++ b/pages/docs/has_one.md
@@ -11,7 +11,7 @@ For example, if your application includes users and credit cards, and each user 
 
 ### Declare
 ```go
-// User has one CreditCard, CreditCardID is the foreign key
+// User has one CreditCard, UserID is the foreign key
 type User struct {
   gorm.Model
   CreditCard CreditCard


### PR DESCRIPTION
- [] **ONLY** change English documents in the Pull Request, translations will be synced and translate them with https://translate.gorm.io/ or it will cause merge conflicts!

### What did this pull request do?

Fix foreign key name in an example for "has one" association
