### PR TITLE
Fix typo in `has_many.md`

### DIFF
--- a/pages/docs/has_many.md
+++ b/pages/docs/has_many.md
@@ -116,7 +116,7 @@ type Toy struct {
   OwnerType string
 }
 
-db.Create(&Dog{Name: "dog1", Toy: []Toy{{Name: "toy1"}, {Name: "toy2"}}})
+db.Create(&Dog{Name: "dog1", Toys: []Toy{{Name: "toy1"}, {Name: "toy2"}}})
 // INSERT INTO `dogs` (`name`) VALUES ("dog1")
 // INSERT INTO `toys` (`name`,`owner_id`,`owner_type`) VALUES ("toy1","1","master"), ("toy2","1","master")
 ```


### PR DESCRIPTION
- [] **ONLY** change English documents in the Pull Request, translations will be synced and translate them with https://translate.gorm.io/ or it will cause merge conflicts!

### What did this pull request do?

This pull request fixes the typo in the has-many documentation. The field's name should be `Toys`, not `Toy`, as is declared on [line 109](https://github.com/go-gorm/gorm.io/blob/master/pages/docs/has_many.md?plain=1#L109).
