### PR TITLE
Fix Twitter and github icons

### DIFF
--- a/themes/navy/layout/partial/footer.swig
+++ b/themes/navy/layout/partial/footer.swig
@@ -15,8 +15,8 @@
       </script>
     </div>
     <div id="footer-links">
-      <a href="https://twitter.com/{{ config.twitter }}" class="footer-link" target="_blank"><i class="fa fa-twitter"></i></a>
-      <a href="https://github.com/{{ config.github }}" class="footer-link" target="_blank"><i class="fa fa-github-alt"></i></a>
+      <a href="https://twitter.com/{{ config.twitter }}" class="footer-link" target="_blank"><i class="fab fa-twitter"></i></a>
+      <a href="https://github.com/{{ config.github }}" class="footer-link" target="_blank"><i class="fab fa-github-alt"></i></a>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
- [x] **ONLY** change English documents in the Pull Request, translations will be synced and translate them with https://translate.gorm.io/ or it will cause merge conflicts!

### What did this pull request do?

In the footer on https://gorm.io/, the Twitter and GitHub icons currently do not look to be rendering correctly, possibly due to a FontAwesome incompatability:

On Firefox these appear as the following:

![image](https://user-images.githubusercontent.com/64075030/218109248-d306bd8d-0a3c-4678-a7d8-44936ae1d9d2.png)

And on Chromium, they are 'invisible':

![image](https://user-images.githubusercontent.com/64075030/218109178-93f10d5a-e78c-417a-991c-3f895e1bdbca.png)


I've updated the classes to use the Font Awesome v5 free icon classes, and they now appear to be working on both Firefox and Chromium:

![image](https://user-images.githubusercontent.com/64075030/218109272-117cc022-bba1-4b99-921c-c4022f4c1df3.png)
