### PR TITLE
Added description in document for Delete by providing slice of structs

### DIFF
--- a/pages/de_DE/docs/delete.md
+++ b/pages/de_DE/docs/delete.md
@@ -57,6 +57,16 @@ db.Delete(&Email{}, "email LIKE ?", "%jinzhu%")
 // DELETE from emails where email LIKE "%jinzhu%";
 ```
 
+## <span id="Delete Multiple Records">Batch Delete</span>
+
+The Multiple value will get deleted with matching user ID 
+```go
+var users []User // For Ex. containing 3 Users with their IDs 1,2 and 3.
+db.Delete(&users)
+// DELETE from user where WHERE id IN (1,2,3)";
+```
+
+
 ### Block Global Delete
 
 If you perform a batch delete without any conditions, GORM WON'T run it, and will return `ErrMissingWhereClause` error

--- a/pages/de_DE/docs/delete.md
+++ b/pages/de_DE/docs/delete.md
@@ -57,15 +57,19 @@ db.Delete(&Email{}, "email LIKE ?", "%jinzhu%")
 // DELETE from emails where email LIKE "%jinzhu%";
 ```
 
-## <span id="Delete Multiple Records">Batch Delete</span>
+## <span id="delete_multiple_records">Delete Multiple Records</span>
 
-The Multiple value will get deleted with matching user ID 
+If slice is passed with primary key then it will delete all the records of that slice with those primary keys 
 ```go
 var users []User // For Ex. containing 3 Users with their IDs 1,2 and 3.
 db.Delete(&users)
-// DELETE from user where WHERE id IN (1,2,3)";
-```
+// DELETE from user where WHERE id IN (1,2,3);
 
+If slice has no primary key the it will perform batch deleting for the matching filed in the slice.  
+var users = []User{{Name: "jinzhu.1"}, {Name: "jinzhu.2"}, {Name: "jinzhu.3"}}
+db.Delete(&users)
+// DELETE from user where WHERE name IN (jinzhu.1,jinzhu.2,jinzhu.3);
+```
 
 ### Block Global Delete
 


### PR DESCRIPTION
 * [x]  **ONLY** change English documents in the Pull Request, translations will be synced and translate them with https://translate.gorm.io/ or it will cause merge conflicts!

**What did this pull request do?**


When doing a db.Delete and passing a slice of structs, GORM will do group delete for all the records present in the slice. This was not mentioned in the documents so added that



Changes done as suggested in ([https://github.com/go-gorm/gorm/issues/6035])
