### PR TITLE
Update many_to_many.md

### DIFF
--- a/pages/docs/many_to_many.md
+++ b/pages/docs/many_to_many.md
@@ -139,7 +139,7 @@ Customized join table's foreign keys required to be composited primary keys or c
 type Person struct {
   ID        int
   Name      string
-  Addresses []Address `gorm:"many2many:person_address;"`
+  Addresses []Address `gorm:"many2many:person_addressses;"`
 }
 
 type Address struct {


### PR DESCRIPTION
When we migrate the structs to database, the plural form of structs is used as a table name. So, the name of the mapping table of Person and Address should also be plural. Else, SetupJoinTable would not work on it and and some other operation on PersonAddress (like using its composite primary keys as foreign keys in another table) will result in new table creation which would be person_addresses.

If we name our mapping table as person_address(plural form) then it update the same table instead of creating the new one.

- [] **ONLY** change English documents in the Pull Request, translations will be synced and translate them with https://translate.gorm.io/ or it will cause merge conflicts!

### What did this pull request do?

<!--
provide a general description of the changes in your pull request
-->
