### PR TITLE
Make dialect translated errors more visible

### DIFF
--- a/pages/docs/error_handling.md
+++ b/pages/docs/error_handling.md
@@ -27,23 +27,26 @@ if result := db.Where("name = ?", "jinzhu").First(&user); result.Error != nil {
 }
 ```
 
+{% note warn %}
+## Dialect Translated Errors
+
+If you would like to be able to use the dialect translated errors(like ErrDuplicatedKey), then enable the `TranslateError` flag when opening a db connection.
+
+```go
+db, err := gorm.Open(postgres.Open(postgresDSN), &gorm.Config{TranslateError: true})
+```
+{% endnote %}
+
+
 ## ErrRecordNotFound
 
-GORM returns `ErrRecordNotFound` when failed to find data with `First`, `Last`, `Take`, if there are several errors happened, you can check the `ErrRecordNotFound` error with `errors.Is`, for example:
+GORM returns `ErrRecordNotFound` when failed to find data with `First`, `Last`, `Take` (only when dialect translated errors are enabled). If there are several errors happened, you can check the `ErrRecordNotFound` error with `errors.Is`. For example,
 
 ```go
 // Check if returns RecordNotFound error
 err := db.First(&user, 100).Error
 errors.Is(err, gorm.ErrRecordNotFound)
 ```
-## Dialect Translated Errors
-
-If you would like to be able to use the dialect translated errors(like ErrDuplicatedKey), then enable the TranslateError flag when opening a db connection.
-
-```go
-db, err := gorm.Open(postgres.Open(postgresDSN), &gorm.Config{TranslateError: true})
-```
-
 ## Errors
 
 [Errors List](https://github.com/go-gorm/gorm/blob/master/errors.go)


### PR DESCRIPTION
When error handling, errors like `ErrRecordNotFound` are available only when Dialect Translated Errors are enabled. This section was not obvious when skimming through the docs and it leads to wasted hours and creations of issues like [#4037](https://github.com/go-gorm/gorm/issues/4037). This commit makes it more visible and fixes a few punctuations

- [x] **ONLY** change English documents in the Pull Request, translations will be synced and translate them with https://translate.gorm.io/ or it will cause merge conflicts!
