### PR TITLE
Fix the typo in dbresolver.md

### DIFF
--- a/pages/docs/dbresolver.md
+++ b/pages/docs/dbresolver.md
@@ -97,13 +97,13 @@ But you can specifies which DB to use before starting a transaction, for example
 
 ```go
 // Start transaction based on default replicas db
-tx := DB.Clauses(dbresolver.Read).Begin()
+tx := db.Clauses(dbresolver.Read).Begin()
 
 // Start transaction based on default sources db
-tx := DB.Clauses(dbresolver.Write).Begin()
+tx := db.Clauses(dbresolver.Write).Begin()
 
 // Start transaction based on `secondary`'s sources
-tx := DB.Clauses(dbresolver.Use("secondary"), dbresolver.Write).Begin()
+tx := db.Clauses(dbresolver.Use("secondary"), dbresolver.Write).Begin()
 ```
 
 ## Load Balancing


### PR DESCRIPTION
### What did this pull request do?

It fixes a typo in the [DBResolver Documentation](https://gorm.io/docs/dbresolver.html). 

It seems like it should be `db.Clauses` not `DB.Clauses`
