### PR TITLE
When printing, wrap lines in code blocks.

### DIFF
--- a/themes/navy/source/css/_partial/highlight.styl
+++ b/themes/navy/source/css/_partial/highlight.styl
@@ -58,6 +58,8 @@ pre
     background: none
   .line
     height: 22px
+    @media print
+      text-wrap: wrap
 
 pre
   .comment


### PR DESCRIPTION
This change ensures that the content of code blocks remains fully visible and readable when printed, by preventing long lines from disappearing off the edge of the page.

Before:
![Screenshot from 2024-03-21 19-49-37](https://github.com/go-gorm/gorm.io/assets/6534428/a4a88b6e-7eee-4f81-83c9-a92f211ffacb)

After:
![Screenshot from 2024-03-21 19-47-36](https://github.com/go-gorm/gorm.io/assets/6534428/02d20e44-7476-4959-82a9-0911738860be)
