### PR TITLE
Fix has_one example references value

### DIFF
--- a/pages/docs/has_one.md
+++ b/pages/docs/has_one.md
@@ -68,7 +68,7 @@ You are able to change it with tag `references`, e.g:
 type User struct {
   gorm.Model
   Name       string     `gorm:"index"`
-  CreditCard CreditCard `gorm:"foreignKey:UserName;references:name"`
+  CreditCard CreditCard `gorm:"foreignKey:UserName;references:Name"`
 }
 
 type CreditCard struct {


### PR DESCRIPTION
- [x] **ONLY** change English documents in the Pull Request, translations will be synced and translate them with https://translate.gorm.io/ or it will cause merge conflicts!

### What did this pull request do?

Fix has_one example references value
