### PR TITLE
Minor clarification on tag format separators

### DIFF
--- a/pages/docs/models.md
+++ b/pages/docs/models.md
@@ -173,7 +173,10 @@ type Blog struct {
 ### <span id="tags">Fields Tags</span>
 
 Tags are optional to use when declaring models, GORM supports the following tags:
-Tags are case insensitive, however `camelCase` is preferred.
+Tags are case insensitive, however `camelCase` is preferred. If multiple tags are
+used they should be separated by a semicolon (`;`). Characters that have special
+meaning to the parser can be escaped with a backslash (`\`) allowing them to be
+used as parameter values.
 
 | Tag Name       | Description                                                            |
 | ---            | ---                                                                    |


### PR DESCRIPTION
- [x] **ONLY** change English documents in the Pull Request, translations will be synced and translate them with https://translate.gorm.io/ or it will cause merge conflicts!

### What did this pull request do?

This is a rather minor change that adds clarification on how to combine multiple tags in a model. It is based on [this code](https://github.com/go-gorm/gorm/blob/4a50b36f638c6899089e6e3457425528ce693933/schema/field.go#L109) for parsing using a semicolon joiner and [this code](https://github.com/go-gorm/gorm/blob/4a50b36f638c6899089e6e3457425528ce693933/schema/utils.go#L16C6-L16C21) for handling escapes within parameters.