### PR TITLE
Update polymorphism.md Dog.Toy -> Dog.[]Toy

### DIFF
--- a/pages/docs/polymorphism.md
+++ b/pages/docs/polymorphism.md
@@ -40,7 +40,7 @@ You can specify polymorphism properties separately using the following GORM tags
 type Dog struct {
   ID   int
   Name string
-  Toys Toy `gorm:"polymorphicType:Kind;polymorphicId:OwnerID;polymorphicValue:master"`
+  Toys []Toy `gorm:"polymorphicType:Kind;polymorphicId:OwnerID;polymorphicValue:master"`
 }
 
 type Toy struct {


### PR DESCRIPTION
### What did this pull request do?

Changed the Dog.Toy relation to []Toy, as per defined in the previous code block. It's a syntax error without the change.
