### PR TITLE
Fix typo in atlas integration docs

### DIFF
--- a/pages/docs/migration.md
+++ b/pages/docs/migration.md
@@ -269,7 +269,7 @@ GORM creates constraints when auto migrating or creating table, see [Constraints
 
 [Atlas](https://atlasgo.io) is an open-source database migration tool that has an official integration with GORM.
 
-While GORM's `AutoMigrate` feature works in most cases, at some point you many need to switch to a [versioned migrations](https://atlasgo.io/concepts/declarative-vs-versioned#versioned-migrations) strategy.
+While GORM's `AutoMigrate` feature works in most cases, at some point you may need to switch to a [versioned migrations](https://atlasgo.io/concepts/declarative-vs-versioned#versioned-migrations) strategy.
 
 Once this happens, the responsibility for planning migration scripts and making sure they are in line with what GORM expects at runtime is moved to developers.
 


### PR DESCRIPTION
- [] **ONLY** change English documents in the Pull Request, translations will be synced and translate them with https://translate.gorm.io/ or it will cause merge conflicts!

### What did this pull request do?

<!--
provide a general description of the changes in your pull request
-->
Fixed a typo in the Atlast Integration section of the Migration documentation

Closes #777