### PR TITLE
Update Save description

### DIFF
--- a/pages/docs/update.md
+++ b/pages/docs/update.md
@@ -16,7 +16,13 @@ db.Save(&user)
 // UPDATE users SET name='jinzhu 2', age=100, birthday='2016-01-01', updated_at = '2013-11-17 21:34:10' WHERE id=111;
 ```
 
-`Save` is a combination function. If save value does not contain primary key, it will execute `Create`, otherwise it will execute `Update` (with all fields).
+`Save` is an upsert function:  
+- If the value contains no primary key, it performs `Create`  
+- If the value has a primary key, it first executes **Update** (all fields, by `Select(*)`).  
+- If `rows affected = 0` after **Update**, it automatically falls back to `Create`.  
+
+> 💡 **Note**: `Save` guarantees either an update or insert will occur.  
+> To prevent unintended creation when no rows match, use [ `Select(*).Updates()` ](update.html#Update-Selected-Fields).
 
 ```go
 db.Save(&User{Name: "jinzhu", Age: 100})


### PR DESCRIPTION
- [] **ONLY** change English documents in the Pull Request, translations will be synced and translate them with https://translate.gorm.io/ or it will cause merge conflicts!

### What did this pull request do?

I believe the documentation should reflect this behavior because, during heavy usage of `Save`, I unexpectedly encountered cases where `rowEffect=0` triggered record creation. Admittedly, this was also due to my own oversight in considering this edge case.
