### PR TITLE
Grammatical improvement query.md

### DIFF
--- a/pages/docs/query.md
+++ b/pages/docs/query.md
@@ -33,7 +33,7 @@ If you want to avoid the `ErrRecordNotFound` error, you could use `Find` like `d
 {% endnote %}
 
 {% note warn %}
-Using `Find` without a limit for single object `db.Find(&user)` will query the full table and return only the first object which is not performant and nondeterministic
+Using `Find` without a limit for single object `db.Find(&user)` will query the full table and return only the first object which is non-deterministic and not performant
 {% endnote %}
 
 The `First` and `Last` methods will find the first and last record (respectively) as ordered by primary key. They only work when a pointer to the destination struct is passed to the methods as argument or when the model is specified using `db.Model()`. Additionally, if no primary key is defined for relevant model, then the model will be ordered by the first field. For example:


### PR DESCRIPTION


- [] **ONLY** change English documents in the Pull Request, translations will be synced and translate them with https://translate.gorm.io/ or it will cause merge conflicts!

### What did this pull request do?

<!--
provide a general description of the changes in your pull request
-->
As for the first change, switched the word order on line 36 to avoid ambiguity in "is not performant  and nondeterministic" (to "is non-deterministic and not performant"). The second change is the preferable spelling of" nonperformant"->"non-performant". The  spelling is listed first in the Cambridge dictionary(dictionary.cambridge.org/dictionary/english/non-deterministic)