### PR TITLE
Add interactive learning platform to Community page

### DIFF
--- a/pages/community.md
+++ b/pages/community.md
@@ -14,6 +14,10 @@ layout: page
 
 * Gitter - [https://gitter.im/jinzhu/gorm](https://gitter.im/jinzhu/gorm)
 
+## Learning Resources
+
+* **Interactive Learning Platform** - [Go Interview Practice](https://github.com/RezaSi/go-interview-practice) - Web-based IDE with progressive GORM challenges covering CRUD operations, associations, migrations, advanced queries, and the new Generics API. Features community leaderboards, real-world scenarios, and hands-on practice.
+
 ## Links
 
 * An admin system based on GORM V2 - [GIN-VUE-ADMIN](https://github.com/flipped-aurora/gin-vue-admin)

--- a/pages/community.md
+++ b/pages/community.md
@@ -16,7 +16,7 @@ layout: page
 
 ## Learning Resources
 
-* **Interactive Learning Platform** - [Go Interview Practice](https://github.com/RezaSi/go-interview-practice) - Web-based IDE with progressive GORM challenges covering CRUD operations, associations, migrations, advanced queries, and the new Generics API. Features community leaderboards, real-world scenarios, and hands-on practice.
+* **Interactive Learning Platform** - [Go Interview Practice](https://app.gointerview.dev/packages/gorm) - Web-based IDE with progressive GORM challenges covering CRUD operations, associations, migrations, advanced queries, and the new Generics API. Features community leaderboards, real-world scenarios, and hands-on practice.
 
 ## Links
 


### PR DESCRIPTION
- [x] **ONLY** change English documents in the Pull Request, translations will be synced and translate them with https://translate.gorm.io/ or it will cause merge conflicts!

### What did this pull request do?

Added a new "Learning Resources" section to the Community page featuring an interactive learning platform for GORM.

**Changes:**
- Added new section between "Chat" and "Links" sections
- Featured the Go Interview Practice platform which provides:
  - Web-based IDE for instant GORM coding (no setup required)
  - Progressive challenges covering CRUD operations, associations, migrations, advanced queries, and the new Generics API
  - Community leaderboards and real-world scenarios
  - Hands-on practice for developers learning GORM

This addresses the community need for practical, interactive learning resources and showcases the new Generics API introduced in GORM v1.30.0+.