### PR TITLE
docs(query): [#895] add generics api to joins documentation

### DIFF
--- a/pages/docs/query.md
+++ b/pages/docs/query.md
@@ -152,6 +152,7 @@ db.Model(User{ID: 10}).First(&result)
 {% note warn %}
 **NOTE:** If you use gorm's specific field types like `gorm.DeletedAt`, it will run a different query for retrieving object/s.
 {% endnote %}
+
 ```go
 type User struct {
   ID           string `gorm:"primarykey;size:16"`
@@ -163,6 +164,7 @@ var user = User{ID: 15}
 db.First(&user)
 //  SELECT * FROM `users` WHERE `users`.`id` = '15' AND `users`.`deleted_at` IS NULL ORDER BY `users`.`id` LIMIT 1
 ```
+
 ## Retrieving all objects
 
 ```go
@@ -210,14 +212,15 @@ db.Where("created_at BETWEEN ? AND ?", lastWeek, today).Find(&users)
 
 {% note warn %}
 If the object's primary key has been set, then condition query wouldn't cover the value of primary key but use it as a 'and' condition. For example:
+
 ```go
 var user = User{ID: 10}
 db.Where("id = ?", 20).First(&user)
 // SELECT * FROM users WHERE id = 10 and id = 20 ORDER BY id ASC LIMIT 1
 ```
+
 This query would give `record not found` Error. So set the primary key attribute such as `id` to nil before you want to use the variable such as `user` to get new value from database.
 {% endnote %}
-
 
 ### Struct & Map Conditions
 
@@ -437,6 +440,33 @@ db.Distinct("name", "age").Order("name, age desc").Find(&results)
 
 ## Joins
 
+### Generics API
+
+The new GORM generics interface brings enhanced support for association queries (`Joins`), offering more flexible association methods, more expressive query capabilities, and a significantly simplified approach to building complex queries.
+
+- **Joins**: Easily specify different join types (e.g., `InnerJoin`, `LeftJoin`) and customize join conditions based on associations, making complex cross-table queries clearer and more intuitive.
+
+```go
+// Load only users who have a company
+users, err := gorm.G[User](db).Joins(clause.Has("Company"), nil).Find(ctx)
+
+// Use Left Join with custom filter on joined table
+user, err = gorm.G[User](db).Joins(clause.LeftJoin.Association("Company"), func(db gorm.JoinBuilder, joinTable clause.Table, curTable clause.Table) error {
+    db.Where(map[string]any{"name": company.Name})
+    return nil
+}).Where(map[string]any{"name": user.Name}).First(ctx)
+
+// Join using a subquery
+users, err = gorm.G[User](db).Joins(clause.LeftJoin.AssociationFrom("Company", gorm.G[Company](DB).Select("Name")).As("t"),
+    func(db gorm.JoinBuilder, joinTable clause.Table, curTable clause.Table) error {
+        db.Where("?.name = ?", joinTable, u.Company.Name)
+        return nil
+    },
+).Find(ctx)
+```
+
+### Traditional API
+
 Specify Joins conditions
 
 ```go
@@ -459,7 +489,7 @@ db.Table("users").Select("users.name, emails.email").Joins("left join emails on 
 db.Joins("JOIN emails ON emails.user_id = users.id AND emails.email = ?", "jinzhu@example.org").Joins("JOIN credit_cards ON credit_cards.user_id = users.id").Where("credit_cards.number = ?", "411111111111").Find(&user)
 ```
 
-### Joins Preloading
+#### Joins Preloading
 
 You can use `Joins` eager loading associations with a single SQL, for example:
 
@@ -481,7 +511,7 @@ db.Joins("Company", db.Where(&Company{Alive: true})).Find(&users)
 
 For more details, please refer to [Preloading (Eager Loading)](preload.html).
 
-### Joins a Derived Table
+#### Joins a Derived Table
 
 You can also use `Joins` to join a derived table.
 
@@ -500,7 +530,6 @@ query := db.Table("order").Select("MAX(order.finished_at) as latest").Joins("lef
 db.Model(&Order{}).Joins("join (?) q on order.finished_at = q.latest", query).Scan(&results)
 // SELECT `order`.`user_id`,`order`.`finished_at` FROM `order` join (SELECT MAX(order.finished_at) as latest FROM `order` left join user user on order.user_id = user.id WHERE user.age > 18 GROUP BY `order`.`user_id`) q on order.finished_at = q.latest
 ```
-
 
 ## <span id="scan">Scan</span>
 


### PR DESCRIPTION
- [x] **ONLY** change English documents in the Pull Request, translations will be synced and translate them with https://translate.gorm.io/ or it will cause merge conflicts!

### What did this pull request do?
The PR fixes #895 

## Problem:
Currently, there is nothing related to the generics API under Query -> Joins.
However, the content does exist. It's just a bit hidden under “The Generics Way to Use GORM.”
It would be very helpful if this content were also available under Query -> Joins.

## Solution
Copied the information from “The Generics Way to Use GORM.” into "Query" Docs.