### PR TITLE
docs: fix Gen create error example in Chinese docs

### DIFF
--- a/pages/zh_CN/gen/create.md
+++ b/pages/zh_CN/gen/create.md
@@ -92,7 +92,7 @@ err := query.User.WithContext(ctx).Clauses(clause.OnConflict{
 // MERGE INTO "users" USING *** WHEN NOT MATCHED THEN INSERT *** WHEN MATCHED THEN UPDATE SET ***; SQL Server
 // INSERT INTO `users` *** ON DUPLICATE KEY UPDATE ***; MySQL
 
-err := query.User.WithContext(ctx).Clauses(clause.OnConflict{DoUpdates: clause.AssignmentColumns([]string{"name", "age"}),}).Create(&user).Error
+err := query.User.WithContext(ctx).Clauses(clause.OnConflict{DoUpdates: clause.AssignmentColumns([]string{"name", "age"}),}).Create(&user)
 // MERGE INTO "users" USING *** WHEN NOT MATCHED THEN INSERT *** WHEN MATCHED THEN UPDATE SET "name"="excluded"."name"; SQL Server
 // INSERT INTO "users" *** ON CONFLICT ("id") DO UPDATE SET "name"="excluded"."name", "age"="excluded"."age"; PostgreSQL
 // INSERT INTO `users` *** ON DUPLICATE KEY UPDATE `name`=VALUES(name),`age`=VALUES(age); MySQL


### PR DESCRIPTION
## What changed

Removed the incorrect `.Error` access from the Chinese GORM Gen `Create` example.

`Create` already returns an error, so accessing `.Error` is invalid.

## Related issue

Fixes #803